### PR TITLE
:building_construction: Restructure 'NamespaceKey'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "overloadlib"
-version = "0.2.2"
+version = "0.2.3"
 description = "A python package to implement overloading of functions in python."
 authors = ["Niclas D. Gesing <nicdomgesing@gmail.com>"]
 license = "MIT"


### PR DESCRIPTION
Add 'NamespaceKeyBase'; Add 'UnorderedNamespaceKey'

## Description

- The previous implementation of NamespaceKey forced constant `isinstance` queries because the `type_hints` were used partly as `frozenset` partly as ordered tuples. 
- Solution: Two `NamespaceKey` classes instead of one:
`NamespaceKey` and `UnorderNamespaceKey` which only differ in the representation of `type_hints`.
- Implementation of a common base class `NamespaceKeyBase` to keep the code more 'DRY'.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 💥 Breaking Changes (fix or feature that would cause existing functionality to change)
- [ ] 🚀 Features (non-breaking change which adds functionality)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🔥 Removals and Deprecations
- [ ] 🐞 Fixes (non-breaking change which fixes an issue)
- [ ] 🐎 Performance
- [ ] 🚨 Testing
- [ ] 👷 Continuous Integration
- [ ] 📚 Documentation
- [x] 🔨 Refactoring
- [ ] 💄 Style
- [ ] 📦 Dependencies
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.rst`](https://github.com/NicDom/overloadlib/blob/master/CODE_OF_CONDUCT.rst) document.
- [x] I've read the [`CONTRIBUTING.rst`](https://github.com/NicDom/overloadlib/blob/master/CONTRIBUTING.rst) guide.
- [x] I've updated the code style using `nox --session=pre-commit`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
